### PR TITLE
Fixed output folder creation

### DIFF
--- a/Tools/main.py
+++ b/Tools/main.py
@@ -57,6 +57,9 @@ for databyte in datafound:
 
 #write converted data to file with name as current timestamp and extension csv in "output" folder of app's folder
 datafile = os.path.dirname(__file__)
+if(datafile == ""):
+	datafile = "."
+
 if getattr(sys, "frozen", False):
 	datafile = os.path.dirname(os.path.dirname(datafile))
 dataroot = os.path.normpath(datafile + "/output")


### PR DESCRIPTION
Under Linux, if the file was started in the current directory, "os.path.dirname(__file__)" just returns "".
Together with the "/output", it wants to create the folder in the filesystem root. Therefore added the check for an empty string.